### PR TITLE
Update/faster workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,23 +14,38 @@ jobs:
       SLACK_USERNAME: CI
       SLACK_ICON: "https://img.icons8.com/ios/50/000000/book-philosophy.png"
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v1
 
-      - uses: borales/actions-yarn@v2.0.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
         with:
-          cmd: install # will run `yarn install` command
+          node-version: '12.x'
 
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: lint # will run `yarn lint` command
+      - name: Get Yarn Cache Dir
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: borales/actions-yarn@v2.0.0
+      - name: Restore Cache
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          cmd: build # will run `yarn build` command
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-      - uses: borales/actions-yarn@v2.0.0
-        with:
-          cmd: test # will run `yarn test` command
+      - name: Install Yarn Packages
+        run: yarn install
+
+      - name: Check Lint
+        run: yarn lint
+
+      - name: Build Project
+        run: yarn build
+
+      - name: Test Project
+        run: yarn test
 
       - uses: rtCamp/action-slack-notify@v2.0.0
         name: Slack Success Notification


### PR DESCRIPTION
🚀 
First run without cache: `succeeded in 2m 5s`
Second run using previous cache: `1m 46s` --> Packages are not downloaded anymore but used from cache

@resanchez @yleprince  But as you can see, just downloading the slack image takes 56 secs ! https://github.com/PetitRoBERT/front-roBERT/runs/453231208?check_suite_focus=true
It's more than half of the pipeline. Maybe we can build our own script in the repo to ping slack from it. If you see what I mean. Just calling a `yarn slack success` for example. With a small script using https://www.npmjs.com/package/@slack/webhook
Edit our message [here](https://api.slack.com/docs/messages/builder?msg=%7B%22attachments%22%3A%5B%7B%22fallback%22%3A%22Required%20plain-text%20summary%20of%20the%20attachment.%22%2C%22color%22%3A%22%2336a64f%22%2C%22pretext%22%3A%22Optional%20text%20that%20appears%20above%20the%20attachment%20block%22%2C%22author_name%22%3A%22Bobby%20Tables%22%2C%22author_link%22%3A%22http%3A%2F%2Fflickr.com%2Fbobby%2F%22%2C%22author_icon%22%3A%22http%3A%2F%2Fflickr.com%2Ficons%2Fbobby.jpg%22%2C%22title%22%3A%22Slack%20API%20Documentation%22%2C%22title_link%22%3A%22https%3A%2F%2Fapi.slack.com%2F%22%2C%22text%22%3A%22Optional%20text%20that%20appears%20within%20the%20attachment%22%2C%22fields%22%3A%5B%7B%22title%22%3A%22Priority%22%2C%22value%22%3A%22High%22%2C%22short%22%3Afalse%7D%5D%2C%22image_url%22%3A%22http%3A%2F%2Fmy-website.com%2Fpath%2Fto%2Fimage.jpg%22%2C%22thumb_url%22%3A%22http%3A%2F%2Fexample.com%2Fpath%2Fto%2Fthumb.png%22%2C%22footer%22%3A%22Slack%20API%22%2C%22footer_icon%22%3A%22https%3A%2F%2Fplatform.slack-edge.com%2Fimg%2Fdefault_application_icon.png%22%2C%22ts%22%3A123456789%7D%5D%7D)